### PR TITLE
Update osc-show-hide.lua to detect OSC state

### DIFF
--- a/osc-show-hide/osc-show-hide.lua
+++ b/osc-show-hide/osc-show-hide.lua
@@ -26,11 +26,9 @@ local options = {
 
 read_options(options, 'osc_show_hide')
 
-local is_hidden = true
-
 local function osc_show_hide()
-  is_hidden = not is_hidden
-  mp.commandv('script-message', 'osc-visibility', (is_hidden and options.hidden_mode or 'always'), 'no-osd')
+  local visibility = require 'mp.utils'.shared_script_property_get('osc-visibility')
+  mp.commandv('script-message', 'osc-visibility', ((visibility == 'auto' or visibility == 'never') and 'always' or options.hidden_mode), 'no-osd')
 end
 
 mp.add_key_binding('/', 'osc-show-hide', osc_show_hide)


### PR DESCRIPTION
Thank you for the osc-show-hide script, I've been using it for a while!

When other scripts manipulate osc-visibility it can assume the wrong OSC state on execution and not change it. The version of your script I was using said:
```
local is_auto = true  -- no way to read the osc mode, 
                         so we assume it starts in auto mode.
```
However, you _can_ actually get the current value, with `require 'mp.utils'.shared_script_property_get('osc-visibility')`

So we can get rid of `is_auto` and make the script more trustworthy.