### PR TITLE
[copy-subtitle] Add Wayland documentation

### DIFF
--- a/copy-subtitle/README.md
+++ b/copy-subtitle/README.md
@@ -14,10 +14,16 @@ This script needs to run an external command in order to copy text to the clipbo
 
 That command is set with the `clipboard_command` option, which has the default value of `'xclip -rmlastnl -selection clipboard'`. See the [_Options_](#options) section for more information.
 
-On Linux, if you don't already have `xclip` installed, you can install it with your distribution's package manager (e.g. on Debian, run `sudo apt install xclip`).
+### Linux
+1. Determine whether your display server is X11 or Wayland.
+2. Use `xclip` or `wl-copy` respectively. The script preset is X11's `xclip`.
+    - **If X11**: Ensure `xclip` is installed.
+    - **If Wayland**: Ensure `wl-clipboard` is installed. Change `clipboard_command` to `'wl-copy'`
 
+### macOS
 On macOS, set the `clipboard_command` option to `pbcopy`.
 
+### Windows
 On Windows, a modification to the script is required. An imperfect example can be found in a previous commit, [here](https://github.com/linguisticmind/mpv-scripts/blob/9d42934a319eb94226abde0851fd4548bc8463a2/copy-subtitle/win/copy-subtitle.lua). Since I don't run Windows, I won't be able to provide much support regarding this issue, but if someone knows a robust solution to this, I would be glad to hear from you. Take a look at this [_Issues_ thread](https://github.com/linguisticmind/mpv-scripts/issues/1) for more information.
 
 ## Options


### PR DESCRIPTION
`wl-copy` is used in Wayland.